### PR TITLE
outs: add remote, push

### DIFF
--- a/examples/valid/outs.dvc.yaml
+++ b/examples/valid/outs.dvc.yaml
@@ -21,6 +21,10 @@ stages:
           meta:
             key: value
             key1: value1
+      - bar5:
+          remote: remote1
+      - bar6:
+          push: false
     live:
       foo:
         summary: true

--- a/gen.py
+++ b/gen.py
@@ -45,6 +45,15 @@ class OutFlags(BaseModel):
     meta: Optional[Dict[str, Any]] = Field(
         None, description="Custom metadata of the output.", title="Meta"
     )
+    remote: Optional[str] = Field(
+        None,
+        description="Name of the remote to use for pushing/fetching",
+    )
+    push: Optional[bool] = Field(
+        True,
+        description="Whether the output should be pushed to remote "
+        "during `dvc push`",
+    )
 
     class Config:
         extra = "forbid"

--- a/schema.json
+++ b/schema.json
@@ -200,6 +200,17 @@
           "title": "Meta",
           "description": "Custom metadata of the output.",
           "type": "object"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Name of the remote to use for pushing/fetching",
+          "type": "string"
+        },
+        "push": {
+          "title": "Push",
+          "description": "Whether the output should be pushed to remote during `dvc push`",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -272,6 +283,17 @@
           "title": "Meta",
           "description": "Custom metadata of the output.",
           "type": "object"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Name of the remote to use for pushing/fetching",
+          "type": "string"
+        },
+        "push": {
+          "title": "Push",
+          "description": "Whether the output should be pushed to remote during `dvc push`",
+          "default": true,
+          "type": "boolean"
         },
         "x": {
           "title": "X",
@@ -380,6 +402,17 @@
           "title": "Meta",
           "description": "Custom metadata of the output.",
           "type": "object"
+        },
+        "remote": {
+          "title": "Remote",
+          "description": "Name of the remote to use for pushing/fetching",
+          "type": "string"
+        },
+        "push": {
+          "title": "Push",
+          "description": "Whether the output should be pushed to remote during `dvc push`",
+          "default": true,
+          "type": "boolean"
         },
         "x": {
           "title": "X",


### PR DESCRIPTION
Adds `remote` and `push` fields to outs schema

Closes https://github.com/iterative/dvc/issues/4868