### PR TITLE
Fix cmd definition union issue for VS Code

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -17,6 +17,10 @@ PlotTemplateName = NewType("PlotTemplateName", str)
 Template = PlotTemplateName | FilePath
 
 
+class Cmds(BaseModel):
+    __root__: list[str]
+
+
 class OutFlags(BaseModel):
     cache: bool | None = Field(True, description="Cache output by DVC")
     persist: bool | None = Field(
@@ -247,7 +251,7 @@ class Stage(BaseModel):
     A named stage of a pipeline.
     """
 
-    cmd: str | list[str] = Field(..., description=CMD_DESC)
+    cmd: str | Cmds = Field(..., description=CMD_DESC)
     wdir: str | None = Field(
         None,
         description="Working directory for the cmd, relative to `dvc.yaml`",

--- a/schema.json
+++ b/schema.json
@@ -92,6 +92,13 @@
         ]
       }
     },
+    "Cmds": {
+      "title": "Cmds",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "DepModel": {
       "title": "DepModel",
       "description": "Path to a dependency (input) file or directory for the stage.",
@@ -367,10 +374,7 @@
               "type": "string"
             },
             {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/definitions/Cmds"
             }
           ]
         },


### PR DESCRIPTION
This PR fixes a union issue for the `cmd` key under `stages` definitions.

### Demo

#### Before

https://github.com/iterative/dvcyaml-schema/assets/37993418/16cf4f2d-d30c-49d2-bc59-9462ee968e0b

#### After

https://github.com/iterative/dvcyaml-schema/assets/37993418/b54d8d6e-61e3-469a-94f4-f7f2bd4331e3


