### PR TITLE
Fix false positive in PyCharm

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -304,7 +304,7 @@ value from the foreach data."""
 
 
 class ParametrizedString(ConstrainedStr):
-    regex = re.compile(r"^\${.*?}$")
+    regex = re.compile(r"^\$\{.*?\}$")
 
 
 class ForeachDo(BaseModel):

--- a/schema.json
+++ b/schema.json
@@ -786,6 +786,9 @@
         "^[a-z0-9]([a-z0-9-/]*[a-z0-9])?$": {
           "$ref": "#/definitions/TopLevelArtifactFlags"
         }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/TopLevelArtifactFlags"
       }
     }
   }

--- a/schema.json
+++ b/schema.json
@@ -473,7 +473,7 @@
           "oneOf": [
             {
               "type": "string",
-              "pattern": "^\\${.*?}$"
+              "pattern": "^\\$\\{.*?\\}$"
             },
             {
               "type": "array",
@@ -612,7 +612,7 @@
               },
               {
                 "type": "string",
-                "pattern": "^\\${.*?}$"
+                "pattern": "^\\$\\{.*?\\}$"
               }
             ]
           }
@@ -786,9 +786,6 @@
         "^[a-z0-9]([a-z0-9-/]*[a-z0-9])?$": {
           "$ref": "#/definitions/TopLevelArtifactFlags"
         }
-      },
-      "additionalProperties": {
-        "$ref": "#/definitions/TopLevelArtifactFlags"
       }
     }
   }


### PR DESCRIPTION
I had false positive validation errors in PyCharm when using variables in `foreach` or `matrix`. Here are some minimal examples using the [valid examples from this repo](https://github.com/iterative/dvcyaml-schema/tree/master/examples/valid):
![image](https://github.com/iterative/dvcyaml-schema/assets/10354968/1128dea6-9618-40ab-be7c-ed1aa06e576a)
![image](https://github.com/iterative/dvcyaml-schema/assets/10354968/4ce9ea0c-d7bf-4627-ba28-1e4cea1e7d3a)

It seems to come from missing escape before "{" and "}" characters.